### PR TITLE
Fix optimizer comment typo

### DIFF
--- a/underlying/lightning_model.py
+++ b/underlying/lightning_model.py
@@ -73,7 +73,7 @@ class LightningModel(pl.LightningModule):
         self.log("train_acc", self.train_acc, on_epoch=True, on_step=False)
         self.model.train()
 
-        return loss  # this is passed to the optimzer for training
+        return loss  # this is passed to the optimizer for training
 
     def validation_step(self, batch, batch_idx):
         loss, true_labels, predicted_labels = self._shared_step(batch)


### PR DESCRIPTION
## Summary
- fix typo in training step comment of `LightningModel`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'config')*

------
https://chatgpt.com/codex/tasks/task_e_68960f76db9c832cab88c0a54322b7da